### PR TITLE
[Fix#53] Firestore 서비스 임포트 방식 및 페이지네이션 메서드 통일

### DIFF
--- a/be/functions/src/controllers/commentController.js
+++ b/be/functions/src/controllers/commentController.js
@@ -1,4 +1,5 @@
-const firestoreService = require("../services/firestoreService");
+const FirestoreService = require("../services/firestoreService");
+const firestoreService = new FirestoreService("comments");
 const {FieldValue} = require("firebase-admin/firestore");
 
 // 댓글 생성 API
@@ -215,16 +216,13 @@ const getComments = async (req, res) => {
       {field: "deleted", operator: "==", value: false},
     ];
 
-    const result = await firestoreService.getCollectionWithPagination(
-        "comments",
-        {
-          page: parseInt(page),
-          size: parseInt(size),
-          orderBy: "createdAt",
-          orderDirection: "asc",
-          where: whereConditions,
-        },
-    );
+    const result = await firestoreService.getWithPagination({
+      page: parseInt(page),
+      size: parseInt(size),
+      orderBy: "createdAt",
+      orderDirection: "asc",
+      where: whereConditions,
+    });
 
     // 모든 댓글을 평면적으로 조회 (부모 댓글 + 대댓글)
     const allComments = [];

--- a/be/functions/src/controllers/gatheringController.js
+++ b/be/functions/src/controllers/gatheringController.js
@@ -1,4 +1,5 @@
-const firestoreService = require("../services/firestoreService");
+const FirestoreService = require("../services/firestoreService");
+const firestoreService = new FirestoreService("gatherings");
 const {FieldValue} = require("firebase-admin/firestore");
 
 // 소모임 목록 조회 - 페이지네이션 지원 (간소화된 정보만 반환)
@@ -7,15 +8,12 @@ const getAllGatherings = async (req, res) => {
     const page = parseInt(req.query.page) || 0;
     const size = parseInt(req.query.size) || 10;
 
-    const result = await firestoreService.getCollectionWithPagination(
-        "gatherings",
-        {
-          page,
-          size,
-          orderBy: "createdAt",
-          orderDirection: "desc",
-        },
-    );
+    const result = await firestoreService.getWithPagination({
+      page,
+      size,
+      orderBy: "createdAt",
+      orderDirection: "desc",
+    });
 
     // 목록에서는 간소화된 정보만 반환 (새로운 BaseItem 구조)
     if (result.content) {
@@ -100,18 +98,16 @@ const getGatheringById = async (req, res) => {
     let communityPosts = [];
     try {
       // 소모임 ID와 동일한 커뮤니티 ID에서 해당 소모임과 관련된 게시글 조회
-      const posts = await firestoreService.getCollectionWithPagination(
-          `communities/${gatheringId}/posts`,
-          {
-            page: 0,
-            size: 10,
-            orderBy: "createdAt",
-            orderDirection: "desc",
-            where: [
-              {field: "type", operator: "==", value: "GATHERING_REVIEW"},
-            ],
-          },
-      );
+      const communityPostsService = new FirestoreService(`communities/${gatheringId}/posts`);
+      const posts = await communityPostsService.getWithPagination({
+        page: 0,
+        size: 10,
+        orderBy: "createdAt",
+        orderDirection: "desc",
+        where: [
+          {field: "type", operator: "==", value: "GATHERING_REVIEW"},
+        ],
+      });
 
       communityPosts = (posts.content || []).map((post) => ({
         id: post.id,

--- a/be/functions/src/controllers/storeController.js
+++ b/be/functions/src/controllers/storeController.js
@@ -1,4 +1,5 @@
-const firestoreService = require("../services/firestoreService");
+const FirestoreService = require("../services/firestoreService");
+const firestoreService = new FirestoreService("products");
 const {FieldValue} = require("firebase-admin/firestore");
 
 const getProducts = async (req, res) => {
@@ -7,16 +8,13 @@ const getProducts = async (req, res) => {
 
     // 인덱스 없이 작동하도록 쿼리 단순화
     // 먼저 모든 상품을 가져온 후 메모리에서 필터링
-    const result = await firestoreService.getCollectionWithPagination(
-        "products",
-        {
-          page: parseInt(page),
-          size: parseInt(size),
-          orderBy: "createdAt",
-          orderDirection: "desc",
-          where: [], // where 조건 제거
-        },
-    );
+    const result = await firestoreService.getWithPagination({
+      page: parseInt(page),
+      size: parseInt(size),
+      orderBy: "createdAt",
+      orderDirection: "desc",
+      where: [], // where 조건 제거
+    });
 
     // 메모리에서 상태 필터링
     if (result.content && status) {

--- a/be/functions/src/controllers/tmiController.js
+++ b/be/functions/src/controllers/tmiController.js
@@ -1,4 +1,5 @@
-const firestoreService = require("../services/firestoreService");
+const FirestoreService = require("../services/firestoreService");
+const firestoreService = new FirestoreService("tmis");
 const {FieldValue} = require("firebase-admin/firestore");
 
 // TMI 프로젝트 목록 조회 (신청/진행/종료 모두 포함) - 페이지네이션 지원
@@ -7,7 +8,7 @@ const getAllTmiProjects = async (req, res) => {
     const page = parseInt(req.query.page) || 0;
     const size = parseInt(req.query.size) || 10;
 
-    const result = await firestoreService.getCollectionWithPagination("tmis", {
+    const result = await firestoreService.getWithPagination({
       page,
       size,
       orderBy: "createdAt",
@@ -93,18 +94,16 @@ const getTmiProjectById = async (req, res) => {
     let communityPosts = [];
     try {
       // TMI 프로젝트 ID와 동일한 커뮤니티 ID에서 해당 TMI 프로젝트와 관련된 게시글 조회
-      const posts = await firestoreService.getCollectionWithPagination(
-          `communities/${projectId}/posts`,
-          {
-            page: 0,
-            size: 10,
-            orderBy: "createdAt",
-            orderDirection: "desc",
-            where: [
-              {field: "type", operator: "==", value: "TMI"},
-            ],
-          },
-      );
+      const communityPostsService = new FirestoreService(`communities/${projectId}/posts`);
+      const posts = await communityPostsService.getWithPagination({
+        page: 0,
+        size: 10,
+        orderBy: "createdAt",
+        orderDirection: "desc",
+        where: [
+          {field: "type", operator: "==", value: "TMI"},
+        ],
+      });
 
       communityPosts = (posts.content || []).map((post) => ({
         id: post.id,

--- a/be/functions/src/services/firestoreService.js
+++ b/be/functions/src/services/firestoreService.js
@@ -1,4 +1,4 @@
-const { db, FieldValue } = require("../config/database");
+const {db, FieldValue} = require("../config/database");
 
 /**
  * Firestore Service (데이터 접근 계층)
@@ -25,7 +25,7 @@ class FirestoreService {
     };
 
     await docRef.set(newData);
-    return { id: docRef.id, ...newData };
+    return {id: docRef.id, ...newData};
   }
 
   /**
@@ -74,7 +74,7 @@ class FirestoreService {
    */
   async update(docId, updateData) {
     await db.collection(this.collectionName).doc(docId).update(updateData);
-    return { id: docId, ...updateData };
+    return {id: docId, ...updateData};
   }
 
   /**
@@ -95,9 +95,9 @@ class FirestoreService {
    */
   async getWhere(field, operator, value) {
     const snapshot = await db
-      .collection(this.collectionName)
-      .where(field, operator, value)
-      .get();
+        .collection(this.collectionName)
+        .where(field, operator, value)
+        .get();
     const items = [];
 
     snapshot.forEach((doc) => {
@@ -135,9 +135,9 @@ class FirestoreService {
       const allResults = [];
       for (const chunk of chunks) {
         const snapshot = await db
-          .collection(this.collectionName)
-          .where(field, "in", chunk)
-          .get();
+            .collection(this.collectionName)
+            .where(field, "in", chunk)
+            .get();
 
         snapshot.forEach((doc) => {
           const data = doc.data();
@@ -155,9 +155,9 @@ class FirestoreService {
     }
 
     const snapshot = await db
-      .collection(this.collectionName)
-      .where(field, "in", values)
-      .get();
+        .collection(this.collectionName)
+        .where(field, "in", values)
+        .get();
 
     const items = [];
     snapshot.forEach((doc) => {
@@ -222,9 +222,9 @@ class FirestoreService {
     let countQuery = db.collection(this.collectionName);
     where.forEach((condition) => {
       countQuery = countQuery.where(
-        condition.field,
-        condition.operator,
-        condition.value
+          condition.field,
+          condition.operator,
+          condition.value,
       );
     });
     const countSnapshot = await countQuery.count().get();
@@ -264,9 +264,9 @@ class FirestoreService {
       const allResults = [];
       for (const chunk of chunks) {
         const snapshot = await db
-          .collection(collectionName)
-          .where(field, "in", chunk)
-          .get();
+            .collection(collectionName)
+            .where(field, "in", chunk)
+            .get();
 
         snapshot.forEach((doc) => {
           const data = doc.data();
@@ -284,9 +284,9 @@ class FirestoreService {
     }
 
     const snapshot = await db
-      .collection(collectionName)
-      .where(field, "in", values)
-      .get();
+        .collection(collectionName)
+        .where(field, "in", values)
+        .get();
 
     const items = [];
     snapshot.forEach((doc) => {


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- routine, tmi, gathering, comment, community, store 컨트롤러의 Firestore 서비스 임포트 방식을 인스턴스 생성 방식으로 통일
- 삭제된 getCollectionWithPagination을 getWithPagination으로  통일

## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #53 

## 🔄 변경사항

<!-- ex)
- FCM 기본 세팅
-->

- 관련 컨트롤러의 Firestore 서비스 임포트를 
 const FirestoreService = require("../services/firestoreService"); 
 const firestoreService = new FirestoreService("컬렉션명"); 방식으로 통일

- 페이지네이션 메서드를 getWithPagination으로 통일

## 👀 리뷰 포인트
<!-- 특히 리뷰받고 싶은 부분이나 확인이 필요한 내용을 적어주세요 -->
<!-- ex)
1. 이 훅에서 이 로직에서 코드 중복이 많이 일어나고 있어요. 어떻게 개선하는 게 좋을까요?
2. 이 함수의 이름을 더 직관적으로 바꿀 수 있는 방법이 있을까요?
 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More reliable loading of community, routine, gathering, store, and TMI lists with consistent pagination.
- Bug Fixes
  - Gathering details now load even if related posts fail to fetch, reducing full-page errors.
- Refactor
  - Unified data fetching across comments, communities, routines, gatherings, store, and TMI for improved consistency and performance.
  - Backend support added for efficient “where in” queries to speed up loading of multiple items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->